### PR TITLE
rewrite implement and allow deregister signal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,65 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --jobs 1 -- --nocapture
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+#           args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-signals"
-version = "0.2.1-alpha.0"
+version = "0.3.0-alpha.0"
 authors = ["Sherlock Holo <sherlockya@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -10,12 +10,10 @@ repository = "https://github.com/Sherlock-Holo/async-signal"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-signal-hook = { version = "0.1", features = ["mio-support"] }
-mio = "0.6"
 lazy_static = "1.4"
 futures-util = "0.3"
-libc = "0.2"
+nix = "0.17"
 
 [dev-dependencies]
 async-std = { version = "1.5", features = ["attributes"] }
-nix = "0.17"
+libc = "0.2"


### PR DESCRIPTION
## rewrite

remove `signal_hook` and `mio` deps, use `nix` to register signal handler.

## feature

allow multi `Signals` handle same unix signals, when a unix signal received, all `Signals` which register it will receive this signal.

## fix

now you can reset signal handler to system default. If you want to handle it again, just new a `Signals`.

## BREAKING CHANGE

`Signals` `Stream` Item change to `c_int`, `Signals::new` return value change to `nix::Result`.